### PR TITLE
docs: add Chinese and Japanese READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,102 @@
+<div align="center">
+
+# Pireel Studio
+
+**トーキングヘッド動画向けの、オープンソースでバックエンド不要の AI 動画エディター。**
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md)
+
+クリップを読み込むと、キャンバスが映像に追従します。編集、ストーリーボード作成、
+デザイングラフィック、キネティックキャプション、テーマ、ライブプレビュー、タイムライン、書き出しは
+すべて**ブラウザー内だけで**動作します。アカウントもサーバーも不要です。
+
+<img src="https://cdn.pireel.com/static/landing/hero.png" alt="Pireel Studio エディター" width="880" />
+
+[![ライセンス：AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
+[![Agent プラグイン](https://img.shields.io/badge/Agent-plugin-8b5cf6.svg)](https://github.com/pireel/pireel-agent)
+&nbsp;·&nbsp; [pireel.com](https://pireel.com)
+
+</div>
+
+---
+
+このリポジトリには、エディターパッケージのソースと、それらを
+通常の Vite アプリとしてマウントする最小構成のシェルが含まれています。Pireel monorepo から一方向に同期されているため、
+[pireel.com](https://pireel.com) のホスティング製品を対象に開発してください。
+
+## クイックスタート
+
+AI コーディング Agent（Codex / Claude
+Code）から操作するのが、Pireel を最もすばやく使う方法です。プラグインをインストールすると、MCP 経由でエディターに接続されます。
+
+```bash
+npx skills add pireel/pireel-agent
+```
+
+または、エディターシェルをローカルで実行します。
+
+```bash
+pnpm install
+pnpm dev
+```
+
+出力された URL を開き、動画をドロップして編集を開始します。下書きは
+`localStorage` に、動画のバイトデータは OPFS に保存され、ブラウザーの外には何も送信されません。
+
+## テーマ
+
+各動画には、パレット、書体、レイアウト表現を含む完全なデザインシステムを適用できます。
+`@pireel/studio-frames` には数十種類が同梱されています。以下はその一例です。
+
+<div align="center">
+
+<img src="https://cdn.pireel.com/static/landing/frame-covers/cinema-frame.webp" alt="Cinema Frame" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/neon-runner.webp" alt="Neon Runner" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/noir-gold.webp" alt="Noir Gold" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/glass-tech.webp" alt="Glass Tech" width="210" />
+<br />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/memphis-pop.webp" alt="Memphis Pop" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/y2k-chrome.webp" alt="Y2K Chrome" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/botanic-press.webp" alt="Botanic Press" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/paper-cut.webp" alt="Paper Cut" width="210" />
+
+</div>
+
+## バックエンドなしで動作する機能
+
+- **ローカル編集**：トーキングヘッドのトラック、ブロック、キャプション、タイムライン、ライブ
+  プレビューはすべてクライアント側で動作します。
+- **クライアント書き出し**：WebCodecs（Chromium）を使用した WYSIWYG 書き出し。
+- **フレームテーマ**：完全なカタログは `@pireel/studio-frames` から提供されます。
+- **ローカルアップロード**：ディスクを使用する開発用ルート（`/local-assets`）に
+  コンテンツアドレス方式のファイルを保存します。これはホスティング環境のアップロード Provider に相当するローカル実装です。
+
+## Provider が必要な機能
+
+生成機能（ブロック構成、ナレーション計画、文字起こし、クラウドメディア
+保管庫、デバイス間同期、画像・動画生成）は、
+`StudioProviders` を通じて注入されます。シェルは `unavailableProviders()` を登録するため、接続するまでは
+該当する処理がヒントを表示して失敗します。有効化する方法は 2 つあります。
+
+1. **独自の Provider を注入**：
+   [`apps/studio-oss/src/providers.ts`](apps/studio-oss/src/providers.ts) にある 5 つの
+   小さなインターフェース（composer / planner / transcriber / vault / projects）を
+   任意のバックエンドまたはローカルモデルに接続できます。
+2. **独自の Agent を使用**：エディターは、外部
+   Agent から MCP 経由で操作できるように設計されています。
+   [Agent プラグイン](https://github.com/pireel/pireel-agent)と、
+   [pireel.com/connect-agent.md](https://pireel.com/connect-agent.md) の接続ガイドを参照してください。
+
+## レイアウト
+
+```
+apps/studio-oss/        # エディターをマウントする最小構成の Vite シェル
+packages/studio-ui/     # エディター UI（ワークベンチ、パネル、タイムライン、クライアント書き出し）
+packages/studio-engine/ # コンポジションコア、Brief、プロンプト、動画編集ユーティリティ
+packages/studio-frames/ # フレームテーマ（デザインシステム）とコンテンツ
+packages/ui/            # 共有プリミティブ、ブランドマーク、テーマトークン
+```
+
+## ライセンス
+
+[AGPL-3.0-only](LICENSE)。

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **An open-source, backend-free AI video editor for talking-head video.**
 
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md)
+
 Import a clip and the canvas follows your footage — editing, storyboarding,
 designed graphics, kinetic captions, themes, live preview, timeline and export
 all run **fully in the browser**. No account, no server.
@@ -88,11 +90,11 @@ fail with a hint until you wire them up. Two ways to light them:
 ## Layout
 
 ```
-apps/studio-oss/        minimal Vite shell that mounts the editor
-packages/studio-ui/     editor UI (workbench, panels, timeline, client export)
-packages/studio-engine/ composition core, briefs, prompts, video-edit utilities
-packages/studio-frames/ frame themes (design systems) + content
-packages/ui/            shared primitives, brand mark, theme tokens
+apps/studio-oss/        # minimal Vite shell that mounts the editor
+packages/studio-ui/     # editor UI (workbench, panels, timeline, client export)
+packages/studio-engine/ # composition core, briefs, prompts, video-edit utilities
+packages/studio-frames/ # frame themes (design systems) + content
+packages/ui/            # shared primitives, brand mark, theme tokens
 ```
 
 ## License

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,102 @@
+<div align="center">
+
+# Pireel Studio
+
+**一款面向口播视频的开源、无后端 AI 视频编辑器。**
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md)
+
+导入视频片段后，画布会随素材呈现——编辑、分镜设计、
+视觉图形、动态字幕、主题、实时预览、时间线和导出
+全都**完全在浏览器中**运行。无需账户，也无需服务器。
+
+<img src="https://cdn.pireel.com/static/landing/hero.png" alt="Pireel Studio 编辑器" width="880" />
+
+[![许可证：AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
+[![Agent 插件](https://img.shields.io/badge/Agent-plugin-8b5cf6.svg)](https://github.com/pireel/pireel-agent)
+&nbsp;·&nbsp; [pireel.com](https://pireel.com)
+
+</div>
+
+---
+
+本仓库包含编辑器软件包的源代码，以及一个用于
+将其挂载为普通 Vite 应用的最简 shell。它由 Pireel monorepo 单向同步；
+请基于 [pireel.com](https://pireel.com) 上的托管产品进行开发。
+
+## 快速开始
+
+使用 AI 编程 Agent（Codex / Claude
+Code）是操控 Pireel 最快捷的方式——安装插件后，它会通过 MCP 连接编辑器：
+
+```bash
+npx skills add pireel/pireel-agent
+```
+
+也可以在本地运行编辑器 shell：
+
+```bash
+pnpm install
+pnpm dev
+```
+
+打开终端输出的 URL，拖入视频即可开始编辑。草稿保存在
+`localStorage` 中，视频字节保存在 OPFS 中——任何内容都不会离开浏览器。
+
+## 主题
+
+每个视频都可以套用一整套设计系统，包括配色、字体和版式语言。
+`@pireel/studio-frames` 随附了数十种主题；以下是其中几种。
+
+<div align="center">
+
+<img src="https://cdn.pireel.com/static/landing/frame-covers/cinema-frame.webp" alt="Cinema Frame" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/neon-runner.webp" alt="Neon Runner" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/noir-gold.webp" alt="Noir Gold" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/glass-tech.webp" alt="Glass Tech" width="210" />
+<br />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/memphis-pop.webp" alt="Memphis Pop" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/y2k-chrome.webp" alt="Y2K Chrome" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/botanic-press.webp" alt="Botanic Press" width="210" />
+<img src="https://cdn.pireel.com/static/landing/frame-covers/paper-cut.webp" alt="Paper Cut" width="210" />
+
+</div>
+
+## 无需后端即可使用的功能
+
+- **本地编辑**：口播视频轨道、内容块、字幕、时间线和实时
+  预览——全部在客户端完成。
+- **客户端导出**：基于 WebCodecs（Chromium）的所见即所得导出。
+- **画框主题**：完整目录由 `@pireel/studio-frames` 提供。
+- **本地上传**：由磁盘支持的开发路由（`/local-assets`）用于存储
+  按内容寻址的文件，是托管上传 Provider 在本地的对应实现。
+
+## 需要 Provider 的功能
+
+生成能力（内容块编排、旁白规划、转录、云媒体
+库、跨设备同步、图像/视频生成）通过
+`StudioProviders` 注入。shell 注册了 `unavailableProviders()`，因此在完成接入前，
+这些路径会失败并显示提示。可以通过两种方式启用：
+
+1. 在
+   [`apps/studio-oss/src/providers.ts`](apps/studio-oss/src/providers.ts) 中**注入自己的 Provider**——其中包含五个
+   小型接口（composer / planner / transcriber / vault / projects），可将它们
+   指向任意后端或本地模型。
+2. **自带 Agent**：编辑器设计为由外部
+   Agent 通过 MCP 驱动。请参阅
+   [Agent 插件](https://github.com/pireel/pireel-agent)以及
+   [pireel.com/connect-agent.md](https://pireel.com/connect-agent.md) 上的连接指南。
+
+## 目录结构
+
+```
+apps/studio-oss/        # 挂载编辑器的最简 Vite shell
+packages/studio-ui/     # 编辑器 UI（工作台、面板、时间线、客户端导出）
+packages/studio-engine/ # 编排核心、Brief、提示词和视频编辑工具
+packages/studio-frames/ # 画框主题（设计系统）和内容
+packages/ui/            # 共享基础组件、品牌标识和主题 Token
+```
+
+## 许可证
+
+[AGPL-3.0-only](LICENSE)。


### PR DESCRIPTION
Adds complete Simplified Chinese and Japanese README translations with language links.

Validated structure, commands, links, images, and paths against the English README.