### PR TITLE
fix(studio-ui): marquee pointercancel, OPFS cache healing, video frame leak

### DIFF
--- a/packages/studio-ui/src/hyperframes-workbench.tsx
+++ b/packages/studio-ui/src/hyperframes-workbench.tsx
@@ -544,8 +544,14 @@ export function HyperframesWorkbench({ projectId, agentView = false }: { project
       // Push only to the active buffer (ImageBitmap transferred once); when the background buffer debuts, the bufs.active effect refreshes to backfill the frame
       // frame2 = the "other side" shadow frame within a transition window (true dual-stream: before cut = B's lead-in, after cut = A's tail)
       const w = iframesRef.current[bufsRef.current.active]?.contentWindow;
+      if (!w) {
+        // No target window (iframe torn down mid-decode): close instead of leaking the bitmaps
+        frame.close();
+        frame2?.close();
+        return;
+      }
       try {
-        w?.postMessage(
+        w.postMessage(
           { type: 'hf:frame', frame, ...(frame2 ? { frame2 } : {}), t: info.t, elKey: info.elKey, srcT: info.srcT },
           '*',
           frame2 ? [frame, frame2] : [frame],

--- a/packages/studio-ui/src/local-media.ts
+++ b/packages/studio-ui/src/local-media.ts
@@ -40,8 +40,9 @@ export async function saveLocalVideo(file: File, sig: string): Promise<void> {
     void navigator.storage.persist?.().catch(() => {});
     const key = sigKey(sig);
     try {
-      await dir.getFileHandle(key);
-      return; // Same sig already on disk (content pinned by size+mtime) — skip rewrite
+      const existing = await (await dir.getFileHandle(key)).getFile();
+      if (existing.size === file.size) return; // Same sig fully on disk (content pinned by size+mtime): skip rewrite
+      // Size mismatch = an interrupted earlier write; fall through and rewrite so the entry heals
     } catch {
       /* Not present → write it */
     }

--- a/packages/studio-ui/src/studio-timeline.tsx
+++ b/packages/studio-ui/src/studio-timeline.tsx
@@ -305,6 +305,7 @@ function StudioTimelineImpl({
     };
     marqueeRafRef.current = requestAnimationFrame(frame);
     const move = (ev: PointerEvent) => {
+      if (ev.buttons === 0) { up(); return; } // missed pointerup: finish immediately, don't track bare movement (same as drag)
       lastX = ev.clientX;
       lastY = ev.clientY;
     };
@@ -312,6 +313,7 @@ function StudioTimelineImpl({
       cancelAnimationFrame(marqueeRafRef.current);
       window.removeEventListener('pointermove', move);
       window.removeEventListener('pointerup', up);
+      window.removeEventListener('pointercancel', up);
       const r = base.getBoundingClientRect();
       const x1 = lastX - r.left;
       const y1 = lastY - r.top;
@@ -321,6 +323,7 @@ function StudioTimelineImpl({
     };
     window.addEventListener('pointermove', move);
     window.addEventListener('pointerup', up);
+    window.addEventListener('pointercancel', up);
   };
   /** Scene-track marquee: drag a rectangle from the track's **top/bottom gap** (or the blank right of the last card); matched shots all enter the multi-select set.
    *  Pressing on a card is intercepted by the card itself for reorder (startShotDrag); the two gestures split by start point, like CapCut. */


### PR DESCRIPTION
Three small robustness fixes in `studio-ui`.

## 1. Timeline marquee never ends on `pointercancel` (`studio-timeline.tsx`)

`startMarquee` registers `pointermove`/`pointerup` but not `pointercancel`, unlike every other drag in the file, and `up()` is the only place that stops the self-rescheduling rAF loop. A cancelled pointer stream (touch/pen, native drag or context-menu interrupt) left the selection rectangle frozen on screen, kept edge auto-scroll running, and pegged one rAF per frame for the rest of the session. Now registers `pointercancel` and adds the same `buttons === 0` bailout the shared `drag()` helper uses for missed pointerups.

## 2. Truncated OPFS video entries never heal (`local-media.ts`)

`saveLocalVideo` treated existence of the sig-keyed file as integrity and skipped the rewrite. A write interrupted mid-stream (tab closed while saving a large file) permanently poisoned that video: every draft restore reconnected a truncated `File`, and `loadLocalVideo` only rejects size 0. Now compares the stored size against the incoming file size and rewrites on mismatch, so one clean save heals the entry.

## 3. Decoded frames leak when the preview iframe is gone (`hyperframes-workbench.tsx`)

`onFrame` relies on the `postMessage` catch block to close the `ImageBitmap`s, but `w?.postMessage` on a nullish window short-circuits without throwing, so the catch never runs. Every frame decoded while the target iframe is torn down (buffer swap clearing srcdoc, unmount before engine dispose) leaked a full-resolution bitmap, roughly 8 MB each at 1080p. Now closes the bitmaps explicitly when there is no target window.

## Verification

- `vitest run`: 299/299 passing.
- `tsc --noEmit`: no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)