### PR TITLE
agent: name the tab's "not mine" errors in one place

### DIFF
--- a/packages/studio-engine/src/component-styles.ts
+++ b/packages/studio-engine/src/component-styles.ts
@@ -1,4 +1,3 @@
-/// <reference path="./css-tree-subpaths.d.ts" />
 // Import only the platform-neutral transforms. The full css-tree entry also loads the lexer
 // and its Node createRequire() data files, which cannot be relocated by the Workers SSR runner.
 import parse from 'css-tree/parser';

--- a/packages/studio-engine/src/mcp.test.ts
+++ b/packages/studio-engine/src/mcp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { V3_TOOLS } from './agent-surface-v3/registry';
-import { STUDIO_TOOLS } from './prompts';
+import { STUDIO_TOOLS, TAB_CANNOT_SERVE_ERRORS } from './prompts';
 import {
   type McpDeps,
   MCP_SERVER_TOOL_IDS,
@@ -96,8 +96,10 @@ describe('MCP v3 surface', () => {
     // client — the very tools an agent needs to start a project or open the editor.
     const callBridge = vi.fn(async (_tool: string, input: unknown) => {
       const name = (input as { name?: string }).name;
-      if (name === 'manage_project') return { ok: false, error: 'project_nav_not_available_in_chat' };
-      if (name === 'create_browser_handoff') return { ok: false, error: 'handoff_not_available_in_chat' };
+      // The codes come from the engine, not from a copy here: a rename must break this test rather
+      // than leave it green while the real handoff stops working.
+      if (name === 'manage_project') return { ok: false, error: TAB_CANNOT_SERVE_ERRORS.projectNav };
+      if (name === 'create_browser_handoff') return { ok: false, error: TAB_CANNOT_SERVE_ERRORS.handoff };
       return { ok: true, summary: 'done' };
     });
     const d = deps({ agentSurface: 'v3', resolveV3Context: v3ctx, callBridge });

--- a/packages/studio-engine/src/mcp.ts
+++ b/packages/studio-engine/src/mcp.ts
@@ -22,7 +22,7 @@ import { translateV3Call, type V3AdapterContext, type LegacyCall } from './agent
 import { V3_RETIRED_TOOL_IDS, V3_TOOL_IDS, V3_TOOLS, v3ReplacementIndex } from './agent-surface-v3/registry';
 import { V3_TOOL_SCHEMAS } from './agent-surface-v3/schemas';
 import { v3Instructions } from './agent-surface-v3/instructions';
-import { MCP_DESCRIPTION_OVERRIDES, STUDIO_TOOLS, STUDIO_TOOL_MAP, mcpInstructions } from './prompts';
+import { MCP_DESCRIPTION_OVERRIDES, STUDIO_TOOLS, STUDIO_TOOL_MAP, TAB_CANNOT_SERVE_ERRORS, mcpInstructions } from './prompts';
 import { MG_BAKE_ROUTE, MG_RUNTIME_CAPABILITIES } from './prompts/block-system';
 import { searchFontsTool } from './font-search-tool';
 
@@ -650,7 +650,7 @@ function readPath(value: unknown, path: string): unknown {
 /** A live tab answering one of these is saying "not mine", the same as having no tab at all: project
  *  navigation and handoff minting are account-level, not document-level, and only the server owns
  *  them. Anything else the tab says is the answer. */
-const TAB_CANNOT_SERVE = new Set(['studio_not_open', 'project_nav_not_available_in_chat', 'handoff_not_available_in_chat']);
+const TAB_CANNOT_SERVE: ReadonlySet<string> = new Set<string>(['studio_not_open', ...Object.values(TAB_CANNOT_SERVE_ERRORS)]);
 
 /** Run one v3 call: translate to legacy calls, apply them in order (chaining results where the adapter
  *  asks), and fold the receipts into one result. Delta shaping lands with the receipt contract. */

--- a/packages/studio-engine/src/prompts/l0-agent-tools.ts
+++ b/packages/studio-engine/src/prompts/l0-agent-tools.ts
@@ -1718,6 +1718,15 @@ export const STUDIO_SKILL_CAPABILITY_CATALOG = STUDIO_SKILL_CAPABILITIES
   .map((capability) => `- ${capability.id}@${capability.version}`)
   .join('\n');
 
+/** Errors meaning "not the open document's to answer": the in-chat runner edits one project and owns
+ *  no account-level capability, so it declines these. mcp.ts reads the same codes off a bridge answer
+ *  to fall an external agent's call through to the server, which does own them. Both sides name them
+ *  from here, so a rename cannot break that handoff while types and tests stay green. */
+export const TAB_CANNOT_SERVE_ERRORS = {
+  projectNav: 'project_nav_not_available_in_chat',
+  handoff: 'handoff_not_available_in_chat',
+} as const;
+
 /** Tool result (client runTool returns → addToolOutput → shared by model + card render). */
 export interface StudioToolResult {
   ok: boolean;

--- a/packages/studio-ui/src/agent-tool-runner.ts
+++ b/packages/studio-ui/src/agent-tool-runner.ts
@@ -113,7 +113,7 @@ import {
 
 
 } from '@pireel/studio-engine/agent-execution-budget';
-import { type StudioToolResult, wrapAgentTranscript } from '@pireel/studio-engine/prompts';
+import { type StudioToolResult, TAB_CANNOT_SERVE_ERRORS, wrapAgentTranscript } from '@pireel/studio-engine/prompts';
 import { rejectStableFramingSplits, visualGeometryForAgent, visualTimelineForAgent } from '@pireel/studio-engine/visual-types';
 import { directorPlanFromSeconds } from '@pireel/studio-engine/director-plan';
 import { applyDirectorPlanToDocument } from '@pireel/studio-engine/director-plan-document';
@@ -4507,22 +4507,22 @@ async function runStudioToolInner(ctx: AgentToolCtx, toolId: string, input: Reco
             }
           }
           // manage_project scope:'project' and create_browser_handoff are account-level, not
-          // document-level: this runner edits the one open project and owns neither. These two error
-          // codes are a contract — mcp.ts TAB_CANNOT_SERVE reads them to fall an external agent's
-          // call through to the server, which does own them. Keep them in step.
+          // document-level: this runner edits the one open project and owns neither. The codes come
+          // from the engine because mcp.ts reads the same ones to fall an external agent's call
+          // through to the server, which does own them.
           case 'list_projects':
           case 'switch_project':
           case 'create_project':
           case 'rename_project':
             return {
               ok: false,
-              error: 'project_nav_not_available_in_chat',
+              error: TAB_CANNOT_SERVE_ERRORS.projectNav,
               data: { fix: 'Listing, switching, creating or renaming projects is an MCP/bridge capability. This chat edits the currently open project — use manage_project scope:output to manage deliverables inside it, or switch projects from the app.' },
             };
           case 'create_browser_handoff':
             return {
               ok: false,
-              error: 'handoff_not_available_in_chat',
+              error: TAB_CANNOT_SERVE_ERRORS.handoff,
               data: { fix: 'Browser handoff mints a one-time code so an external agent can open the editor in its own browser. In this chat the user is already in the editor, so no handoff is needed.' },
             };
           default:


### PR DESCRIPTION
Follow-up from reviewing the agent-surface fixes.

The in-chat runner declines two account-level capabilities with the error codes `project_nav_not_available_in_chat` and `handoff_not_available_in_chat`. The MCP surface matches on those exact strings to fall an external agent's call through to the server, which does own them.

That contract lived as string literals in two packages, with a third hand-copied into the test that covers it. Renaming either one would have left the type check, the tests and lint all green while the handoff silently broke again, which is the same failure this contract exists to prevent.

Both sides and the test now read the codes from one exported constant in the engine.

Verified: type check clean across the workspace, 1021 engine tests and 538 UI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUWCTxGAriJgViGPZxTKVE